### PR TITLE
Improve the confirmation message for `/faq-set`

### DIFF
--- a/setFAQ.py
+++ b/setFAQ.py
@@ -33,6 +33,6 @@ def setter_handler(event, context):
                 }
             )
             
-            response = "Successfully set {} to {}".format(faq_key, faq_response)
+            response = "Successfully set `{}` to\n\n>>> {}".format(faq_key, faq_response)
 
         return { "response_type": "in_channel", "text": response}


### PR DESCRIPTION
Should change the set message to look like this:

![image](https://user-images.githubusercontent.com/2085622/33749579-523e61d4-db83-11e7-8f8f-cbc521ae5735.png)
